### PR TITLE
Update signals.c

### DIFF
--- a/signals.c
+++ b/signals.c
@@ -28,7 +28,7 @@ void stphandler(int sig_num)
         return;
     if (f_current.pid != -1)
     {
-        kill(SIGTTIN, f_current.pid);
+        kill(f_current.pid ,SIGTTIN);
         signal(SIGTSTP, stphandler);
         bg_jobs[num_job].pid = f_current.pid;
         strcpy(bg_jobs[num_job].name, f_current.name);


### PR DESCRIPTION
The arguments for kill should be in the order (PID, SIGNAL). The corrected version ensures that the kill function is invoked with the correct arguments: the process ID (f_current.pid) followed by the signal (SIGTTIN). The correction is necessary to achieve the intended behavior of sending the SIGTTIN signal to the specified process.