### PR TITLE
Update signals.c

### DIFF
--- a/signals.c
+++ b/signals.c
@@ -28,7 +28,7 @@ void stphandler(int sig_num)
         return;
     if (f_current.pid != -1)
     {
-        kill(SIGTTIN, f_current.pid);
+        kill(f_current.pid, SIGTTIN);
         signal(SIGTSTP, stphandler);
         bg_jobs[num_job].pid = f_current.pid;
         strcpy(bg_jobs[num_job].name, f_current.name);


### PR DESCRIPTION
The arguments for kill should be in the order (PID, SIGNAL), but it appears to be used as (SIGNAL, PID). This change ensures that the signal is sent to the process with the ID( f_current.pid).  
Using the correct order of arguments is important for the proper functioning of the kill function.